### PR TITLE
Add open, delete, drag & drop notification actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ For the program to work, you will need the following dependencies installed:
   screenshot to the clipboard.
 - [`swappy`](https://github.com/jtheoof/swappy) (optional) to edit the captured
   screenshot.
+- [`dragon`](https://github.com/mwh/dragon) (optional) to drag and drop the
+  captured screenshot.
 
 ## Bind to the `Print` key
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ For the program to work, you will need the following dependencies installed:
   screenshot.
 - [`dragon`](https://github.com/mwh/dragon) (optional) to drag and drop the
   captured screenshot.
+- [`xdg-utils`](https://www.freedesktop.org/wiki/Software/xdg-utils/)
+  (optional) to open the captured screenshot with the default image viewer.
 
 ## Bind to the `Print` key
 

--- a/sway-interactive-screenshot
+++ b/sway-interactive-screenshot
@@ -317,8 +317,21 @@ class DeleteNotificationAction(NotificationAction):
         notify("Screenshot deleted")
 
 
+class DragonNotificationAction(NotificationAction):
+    name = "dragon"
+    description = "Drag and drop screenshot"
+
+    @classmethod
+    def run(cls, *, filepath: Path) -> None:
+        subprocess.run(["dragon-drop", filepath.expanduser()], check=False)
+
+
 NOTIFICATION_ACTIONS = {
-    action.name: action for action in (EditNotificationAction, DeleteNotificationAction)
+    action.name: action for action in (
+        EditNotificationAction,
+        DeleteNotificationAction,
+        DragonNotificationAction,
+    )
 }
 
 

--- a/sway-interactive-screenshot
+++ b/sway-interactive-screenshot
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import abc
 import os
 import json
 import subprocess
@@ -285,6 +286,42 @@ def copy_file_to_clipboard(filepath: str) -> None:
             process.wait()
 
 
+class NotificationAction(abc.ABC):
+    name: str
+    description: str
+
+    @classmethod
+    @abc.abstractmethod
+    def run(cls, *, filepath: Path) -> None:
+        pass
+
+
+class EditNotificationAction(NotificationAction):
+    name = "default"
+    description = "Edit screenshot"
+
+    @classmethod
+    def run(cls, *, filepath: Path) -> None:
+        filepath_str = str(filepath.expanduser())
+        edit_capture(filepath_str)
+        copy_file_to_clipboard(filepath_str)
+
+
+class DeleteNotificationAction(NotificationAction):
+    name = "delete"
+    description = "Delete screenshot"
+
+    @classmethod
+    def run(cls, *, filepath: Path) -> None:
+        filepath.expanduser().unlink()
+        notify("Screenshot deleted")
+
+
+NOTIFICATION_ACTIONS = {
+    action.name: action for action in (EditNotificationAction, DeleteNotificationAction)
+}
+
+
 def main():
     save_path = Path(os.getenv("SWAY_INTERACTIVE_SCREENSHOT_SAVEDIR", "~"))
     save_path.expanduser().mkdir(parents=True, exist_ok=True)
@@ -314,15 +351,18 @@ def main():
         choice.capture(filepath=filepath.expanduser())
         copy_file_to_clipboard(filepath.expanduser())
 
-        action = notify(
+        action_name = notify(
             "Screenshot",
             summary=f"File saved as <i>{filepath}</i>.",
             icon=filepath.expanduser(),
-            actions=(("default", "Edit"),),
+            actions=[
+                (action.name, action.description)
+                for action in NOTIFICATION_ACTIONS.values()
+            ],
         )
-        if action == "default":
-            edit_capture(filepath.expanduser())
-            copy_file_to_clipboard(filepath.expanduser())
+        action = NOTIFICATION_ACTIONS.get(action_name)
+        if action is not None:
+            action.run(filepath=filepath)
 
     except Exception as err:  # pylint: disable=broad-except
         if isinstance(err, CanceledError):

--- a/sway-interactive-screenshot
+++ b/sway-interactive-screenshot
@@ -326,11 +326,21 @@ class DragonNotificationAction(NotificationAction):
         subprocess.run(["dragon-drop", filepath.expanduser()], check=False)
 
 
+class OpenNotificationAction(NotificationAction):
+    name = "open"
+    description = "Open screenshot"
+
+    @classmethod
+    def run(cls, *, filepath: Path) -> None:
+        subprocess.run(["xdg-open", filepath.expanduser()], check=False)
+
+
 NOTIFICATION_ACTIONS = {
     action.name: action for action in (
         EditNotificationAction,
         DeleteNotificationAction,
         DragonNotificationAction,
+        OpenNotificationAction,
     )
 }
 


### PR DESCRIPTION
On top of the default action which edits the captured screenshot with `swappy`, this enables to also perform other actions such as opening, deleting or drag and dropping the screenshot.

Here, an example of how this can look like:
![image](https://user-images.githubusercontent.com/19509728/210183948-07737171-1862-4dbf-ad37-94527e23110a.png)

New optional dependencies are [dragon](https://github.com/mwh/dragon) and [xdg-utils](https://www.freedesktop.org/wiki/Software/xdg-utils/).