### PR TITLE
Non active Output's don't have the focused field

### DIFF
--- a/sway-interactive-screenshot
+++ b/sway-interactive-screenshot
@@ -337,11 +337,12 @@ def get_outputs() -> Iterator[Output]:
         check=True,
     )
     for output in json.loads(process.stdout.decode()):
-        yield Output(
-            name=output["name"],
-            model=output["model"],
-            focused=output["focused"],
-        )
+        if output["active"]:
+            yield Output(
+                name=output["name"],
+                model=output["model"],
+                focused=output["focused"],
+            )
 
 
 def ask(


### PR DESCRIPTION
sway version 1.7

My setup has multiple monitors, and I turn off (mark as non active) my laptop screen. This was crashing the script with a `KeyError "focused"` error.

This fixes an issue when having outputs as non active (active = False)
 - If the output is non active, they don't have the "focused" property among others
 - As they are non active, it doesn't make sense to list them

Example of a non-active output:
```json
{
    "type": "output",
    "name": "eDP-1",
    "active": false,
    "dpms": false,
    "primary": false,
    "make": "Unknown",
    "model": "0x086E",
    "serial": "0x00000000",
    "modes": [
      {
        "width": 1920,
        "height": 1080,
        "refresh": 60003
      },
      {
        "width": 1920,
        "height": 1080,
        "refresh": 48002
      }
    ],
    "current_workspace": null,
    "rect": {
      "x": 0,
      "y": 0,
      "width": 0,
      "height": 0
    },
    "percent": null
  }
```