### PR TITLE
Fix default config file not being used

### DIFF
--- a/sway-interactive-screenshot
+++ b/sway-interactive-screenshot
@@ -157,7 +157,7 @@ class Config:
             xdg_config_home = os.getenv("XDG_CONFIG_HOME", "~/.config")
             filepath = Path(xdg_config_home) / "sway-interactive-screenshot/config.toml"
 
-        filepath = Path(filepath)
+        filepath = Path(filepath).expanduser()
 
         if filepath.exists():
             with open(filepath, "rb") as f:


### PR DESCRIPTION
When using the user home var "~" (when XDG_CONFIG_HOME is not set) the `exists` function always returns False.

I'm unsure if this is always the case on all python versions, but at least on my current version it's an issue.

I was checking the docs and the [exists](https://docs.python.org/3/library/pathlib.html#pathlib.Path.exists) method doesn't say anything about that.
The [expanduser](https://docs.python.org/3/library/pathlib.html#pathlib.Path.expanduser) method says that if `~` is not found, it returns the same path (well, it says it on the [os.path](https://docs.python.org/3/library/os.path.html#os.path.expanduser) doc). So it should be safe to add that call.

```
$ python
Python 3.10.9 (main, Dec  7 2022, 00:00:00) [GCC 12.2.1 20221121 (Red Hat 12.2.1-4)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pathlib
>>> pathlib.Path("~").exists()
False
>>> pathlib.Path("~").expanduser().exists()
True
```
