### PR TITLE
added config_getter parameter to OpenNotificationAction

### DIFF
--- a/sway-interactive-screenshot
+++ b/sway-interactive-screenshot
@@ -574,7 +574,7 @@ class OpenNotificationAction(NotificationAction):
     description = "Open"
 
     @classmethod
-    def run(cls, *, filepath: Path) -> None:
+    def run(cls, *, filepath: Path, config_getter: Callable[[str], Any]) -> None:
         subprocess.run(["xdg-open", filepath.expanduser()], check=False)
 
 


### PR DESCRIPTION
Using the Open action on the notification would fail, since the `config_getter` argument would get passed to `action.run(..)`, but that argument was unexpected for OpenNotificationAction.

My suggestion is to add that parameter even if the action does not need it. It fixed the issue for me.