### PR TITLE
Add rofi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ audio = "ask" # "yes", "no"
 # Alternative name for dragon-drop binary
 dragon.command = "dragon"
 
-[rofi]
-use_rofi = false
-rofi_theme = ""
+[ask]
+command = "fuzzel" 
+args = []
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ For the program to work, you will need the following dependencies installed:
   [`mako`](https://github.com/emersion/mako)).
 - [`wl-clipboard`](https://github.com/bugaevc/wl-clipboard) to copy the
   screenshot to the clipboard.
+- [`rofi`](https://github.com/lbonn/rofi) (optional) to use rofi instead of fuzzel
 - [`swappy`](https://github.com/jtheoof/swappy) (optional) to edit the captured
   screenshot.
 - [`dragon`](https://github.com/mwh/dragon) (optional) to drag and drop the
@@ -108,6 +109,10 @@ audio = "ask" # "yes", "no"
 [notification_actions]
 # Alternative name for dragon-drop binary
 dragon.command = "dragon"
+
+[rofi]
+use_rofi = false
+rofi_theme = ""
 
 ```
 

--- a/sway-interactive-screenshot
+++ b/sway-interactive-screenshot
@@ -359,6 +359,39 @@ def get_outputs() -> Iterator[Output]:
             )
 
 
+def ask_rofi(
+    choices: List[Any],
+    *,
+    prompt: Optional[str] = None,
+    lines: Optional[int] = None,
+    index: bool = False,
+) -> Union[int, str, None]:
+    args = ["rofi", "-dmenu"]
+
+    if index:
+        args.extend(("-format","i"))
+
+    if prompt is not None:
+        args.extend(("-p", prompt))
+
+    if lines is not None:
+        args.extend(("-l", str(lines)))
+
+    process = subprocess.run(
+        args,
+        input=b"\n".join(str(choice).encode() for choice in choices),
+        capture_output=True,
+        check=False,
+    )
+
+    if process.returncode != 0:
+        return None
+
+    stdout = process.stdout.decode()
+
+    return int(stdout) if index else stdout.strip()
+
+
 def ask(
     choices: List[Any],
     *,

--- a/sway-interactive-screenshot
+++ b/sway-interactive-screenshot
@@ -104,6 +104,10 @@ class Config:
                 "command": "dragon-drop",
             }
         },
+        "rofi" : {
+            "use_rofi" : False,
+            "rofi_theme": "",
+        }
     }
 
     _validate = staticmethod(
@@ -136,6 +140,12 @@ class Config:
                                 "command": config_type_validator(str),
                             }
                         )
+                    }
+                ),
+                "rofi" : config_dict_validator(
+                    {
+                        "use_rofi" : config_type_validator(bool),
+                        "rofi_theme" : config_type_validator(str),
                     }
                 ),
             }
@@ -365,8 +375,12 @@ def ask_rofi(
     prompt: Optional[str] = None,
     lines: Optional[int] = None,
     index: bool = False,
+    theme: str = ""
 ) -> Union[int, str, None]:
     args = ["rofi", "-dmenu"]
+    
+    if len(theme) != 0:
+        args.extend(("-theme", theme))
 
     if index:
         args.extend(("-format","i"))
@@ -663,6 +677,16 @@ def parse_arguments():
     return args
 
 
+class Rofi:
+    use_rofi = False 
+    rofi_theme = ""
+
+    def __init__(self, d=None) -> None:
+         if d is not None:
+            for key, value in d.items():
+                setattr(self, key, value)
+
+
 class CaptureMode(abc.ABC):
     def __init__(self, config_getter: Callable[[str], Any]) -> None:
         self.config_getter = config_getter
@@ -684,7 +708,7 @@ class CaptureMode(abc.ABC):
         return False
 
     @abc.abstractmethod
-    def capture(self, *, area: Area, filepath: str) -> None:
+    def capture(self, *, area: Area, filepath: str, rofi: Rofi) -> None:
         pass
 
     @abc.abstractmethod
@@ -699,7 +723,7 @@ class Screenshot(CaptureMode):
     def get_display_name(self) -> str:
         return "Screenshot"
 
-    def capture(self, *, area: Area, filepath: str) -> None:
+    def capture(self, *, area: Area, filepath: str, rofi: Rofi) -> None:
         take_screenshot(
             filepath=filepath,
             geometry=area.geometry,
@@ -753,16 +777,26 @@ class Screencast(CaptureMode):
 
         return False
 
-    def capture(self, *, area: Area, filepath: str) -> None:
+    def capture(self, *, area: Area, filepath: str, rofi: Rofi) -> None:
         audio_raw_input = self.config_getter("audio")
         if audio_raw_input == "ask":
-            audio_raw_input = ask(["yes", "no"], prompt=self.get_prompt() + "Audio? ")
+            audio_raw_input = ""
+            if rofi.use_rofi:
+                audio_raw_input = ask_rofi(["yes", "no"], prompt=self.get_prompt() + "Audio? ", theme=rofi.rofi_theme)
+            else:
+                audio_raw_input = ask(["yes", "no"], prompt=self.get_prompt() + "Audio? ")
             if audio_raw_input is None:
                 raise CanceledError("No audio preference selected.")
 
-        start_recording = ask(
-            ["yes", "cancel"], prompt=self.get_prompt() + "Start recording? "
-        )
+        start_recording =  ""
+        if rofi.use_rofi:
+            start_recording = ask_rofi(
+                ["yes", "cancel"], prompt=self.get_prompt() + "Start recording? ", theme=rofi.rofi_theme
+            )
+        else:
+            start_recording = ask(
+                ["yes", "cancel"], prompt=self.get_prompt() + "Start recording? "
+            )
         if start_recording != "yes":
             raise CanceledError()
 
@@ -795,6 +829,8 @@ def main():
         if mode.early_exit():
             return
 
+        rofi = Rofi(config.get("rofi"))
+        
         save_dir = args.save_dir
         if save_dir is None:
             save_dir = mode.get_save_dir()
@@ -817,7 +853,14 @@ def main():
                 *get_windows(),
             ]
 
-            choice_idx = ask(choices, prompt=mode.get_prompt(), index=True)
+            choice_idx = None
+            
+            print(rofi)
+
+            if rofi.use_rofi:
+                choice_idx = ask_rofi(choices, prompt=mode.get_prompt(), index=True,theme=rofi.rofi_theme)
+            else:
+                choice_idx = ask(choices, prompt=mode.get_prompt(), index=True)
             if choice_idx is None:
                 return
             if choice_idx == -1:
@@ -831,7 +874,7 @@ def main():
         if not filepath:
             filepath = save_dir / mode.get_filename()
 
-        mode.capture(filepath=str(filepath.expanduser()), area=area)
+        mode.capture(filepath=str(filepath.expanduser()), area=area, rofi=rofi)
 
         action_name = notify(
             mode.get_display_name(),

--- a/sway-interactive-screenshot
+++ b/sway-interactive-screenshot
@@ -104,9 +104,9 @@ class Config:
                 "command": "dragon-drop",
             }
         },
-        "rofi" : {
-            "use_rofi" : False,
-            "rofi_theme": "",
+        "ask" : {
+            "command" : "fuzzel",
+            "args": [],
         }
     }
 
@@ -142,10 +142,10 @@ class Config:
                         )
                     }
                 ),
-                "rofi" : config_dict_validator(
+                "ask" : config_dict_validator(
                     {
-                        "use_rofi" : config_type_validator(bool),
-                        "rofi_theme" : config_type_validator(str),
+                        "command" : config_type_validator(str),
+                        "args" : config_type_validator(List),
                     }
                 ),
             }
@@ -375,12 +375,9 @@ def ask_rofi(
     prompt: Optional[str] = None,
     lines: Optional[int] = None,
     index: bool = False,
-    theme: str = ""
+    additional_args: Optional[List[str]] = None
 ) -> Union[int, str, None]:
     args = ["rofi", "-dmenu"]
-    
-    if len(theme) != 0:
-        args.extend(("-theme", theme))
 
     if index:
         args.extend(("-format","i"))
@@ -390,6 +387,10 @@ def ask_rofi(
 
     if lines is not None:
         args.extend(("-l", str(lines)))
+
+    print(additional_args)
+    if additional_args is not None:
+        args.extend(additional_args)
 
     process = subprocess.run(
         args,
@@ -406,12 +407,13 @@ def ask_rofi(
     return int(stdout) if index else stdout.strip()
 
 
-def ask(
+def ask_fuzzel(
     choices: List[Any],
     *,
     prompt: Optional[str] = None,
     lines: Optional[int] = None,
     index: bool = False,
+    additional_args: Optional[List[str]] = None
 ) -> Union[int, str, None]:
     args = ["fuzzel", "--dmenu"]
 
@@ -424,6 +426,9 @@ def ask(
     if lines is not None:
         args.extend(("--lines", str(lines)))
 
+    if additional_args is not None:
+        args.extend(additional_args)
+
     process = subprocess.run(
         args,
         input=b"\n".join(str(choice).encode() for choice in choices),
@@ -438,6 +443,14 @@ def ask(
 
     return int(stdout) if index else stdout.strip()
 
+
+ASK_FNS = {
+    "rofi" : ask_rofi,
+    "fuzzel" : ask_fuzzel
+}
+
+
+ask = ask_fuzzel
 
 def notify(
     title: str,
@@ -677,16 +690,6 @@ def parse_arguments():
     return args
 
 
-class Rofi:
-    use_rofi = False 
-    rofi_theme = ""
-
-    def __init__(self, d=None) -> None:
-         if d is not None:
-            for key, value in d.items():
-                setattr(self, key, value)
-
-
 class CaptureMode(abc.ABC):
     def __init__(self, config_getter: Callable[[str], Any]) -> None:
         self.config_getter = config_getter
@@ -708,7 +711,7 @@ class CaptureMode(abc.ABC):
         return False
 
     @abc.abstractmethod
-    def capture(self, *, area: Area, filepath: str, rofi: Rofi) -> None:
+    def capture(self, *, area: Area, filepath: str) -> None:
         pass
 
     @abc.abstractmethod
@@ -723,7 +726,7 @@ class Screenshot(CaptureMode):
     def get_display_name(self) -> str:
         return "Screenshot"
 
-    def capture(self, *, area: Area, filepath: str, rofi: Rofi) -> None:
+    def capture(self, *, area: Area, filepath: str) -> None:
         take_screenshot(
             filepath=filepath,
             geometry=area.geometry,
@@ -777,24 +780,14 @@ class Screencast(CaptureMode):
 
         return False
 
-    def capture(self, *, area: Area, filepath: str, rofi: Rofi) -> None:
+    def capture(self, *, area: Area, filepath: str) -> None:
         audio_raw_input = self.config_getter("audio")
         if audio_raw_input == "ask":
-            audio_raw_input = ""
-            if rofi.use_rofi:
-                audio_raw_input = ask_rofi(["yes", "no"], prompt=self.get_prompt() + "Audio? ", theme=rofi.rofi_theme)
-            else:
-                audio_raw_input = ask(["yes", "no"], prompt=self.get_prompt() + "Audio? ")
+            audio_raw_input = ask(["yes", "no"], prompt=self.get_prompt() + "Audio? ")
             if audio_raw_input is None:
                 raise CanceledError("No audio preference selected.")
 
-        start_recording =  ""
-        if rofi.use_rofi:
-            start_recording = ask_rofi(
-                ["yes", "cancel"], prompt=self.get_prompt() + "Start recording? ", theme=rofi.rofi_theme
-            )
-        else:
-            start_recording = ask(
+        start_recording = start_recording = ask(
                 ["yes", "cancel"], prompt=self.get_prompt() + "Start recording? "
             )
         if start_recording != "yes":
@@ -829,7 +822,10 @@ def main():
         if mode.early_exit():
             return
 
-        rofi = Rofi(config.get("rofi"))
+        ask =  partial(
+            ASK_FNS[config.get("ask","command")],
+            additional_args=config.get("ask","args")
+        )
         
         save_dir = args.save_dir
         if save_dir is None:
@@ -855,12 +851,7 @@ def main():
 
             choice_idx = None
             
-            print(rofi)
-
-            if rofi.use_rofi:
-                choice_idx = ask_rofi(choices, prompt=mode.get_prompt(), index=True,theme=rofi.rofi_theme)
-            else:
-                choice_idx = ask(choices, prompt=mode.get_prompt(), index=True)
+            choice_idx = ask(choices, prompt=mode.get_prompt(), index=True)
             if choice_idx is None:
                 return
             if choice_idx == -1:

--- a/sway-interactive-screenshot
+++ b/sway-interactive-screenshot
@@ -77,6 +77,20 @@ def config_enum_validator(values: Set[Any]) -> CONFIG_VALIDATOR:
 
     return validate
 
+def config_list_validator(*types: Type) -> CONFIG_VALIDATOR:
+    def validate(path: str, value: Any) -> Iterator[ValidationError]:
+        if not isinstance(value, list):
+            yield ValidationError(path, f"Expected a list")
+            return
+
+        for i, element in enumerate(value):
+            if not isinstance(element, types):
+                yield ValidationError(
+                    f"{path}[{i}]", f"Type {type(value)} is not one of {', '.join(types)}."
+                )
+
+    return validate
+
 
 class ConfigError(Exception):
     def __init__(self, errors: List[ValidationError]) -> None:
@@ -145,7 +159,7 @@ class Config:
                 "ask" : config_dict_validator(
                     {
                         "command" : config_type_validator(str),
-                        "args" : config_type_validator(List),
+                        "args" : config_list_validator(str),
                     }
                 ),
             }
@@ -388,8 +402,7 @@ def ask_rofi(
     if lines is not None:
         args.extend(("-l", str(lines)))
 
-    print(additional_args)
-    if additional_args is not None:
+    if additional_args:
         args.extend(additional_args)
 
     process = subprocess.run(
@@ -426,7 +439,7 @@ def ask_fuzzel(
     if lines is not None:
         args.extend(("--lines", str(lines)))
 
-    if additional_args is not None:
+    if additional_args:
         args.extend(additional_args)
 
     process = subprocess.run(
@@ -822,7 +835,8 @@ def main():
         if mode.early_exit():
             return
 
-        ask =  partial(
+        global ask
+        ask = partial(
             ASK_FNS[config.get("ask","command")],
             additional_args=config.get("ask","args")
         )
@@ -849,8 +863,6 @@ def main():
                 *get_windows(),
             ]
 
-            choice_idx = None
-            
             choice_idx = ask(choices, prompt=mode.get_prompt(), index=True)
             if choice_idx is None:
                 return

--- a/sway-interactive-screenshot
+++ b/sway-interactive-screenshot
@@ -787,7 +787,7 @@ class Screencast(CaptureMode):
             if audio_raw_input is None:
                 raise CanceledError("No audio preference selected.")
 
-        start_recording = start_recording = ask(
+        start_recording = ask(
                 ["yes", "cancel"], prompt=self.get_prompt() + "Start recording? "
             )
         if start_recording != "yes":
@@ -865,7 +865,7 @@ def main():
         if not filepath:
             filepath = save_dir / mode.get_filename()
 
-        mode.capture(filepath=str(filepath.expanduser()), area=area, rofi=rofi)
+        mode.capture(filepath=str(filepath.expanduser()), area=area)
 
         action_name = notify(
             mode.get_display_name(),


### PR DESCRIPTION
Add support for Rofi. It can be set instead of Fuzzel with the config. Additional arguments can now be passed to it and Fuzzel. This is useful for settings themes for example, e.g.:

```toml
[ask]
command = "rofi"
args = ["-theme", "Indego"]
```

Closes #16.