### PR TITLE
Add Wofi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ For the program to work, you will need the following dependencies installed:
 - [`wl-clipboard`](https://github.com/bugaevc/wl-clipboard) to copy the
   screenshot to the clipboard.
 - [`rofi`](https://github.com/lbonn/rofi) (optional) to use rofi instead of fuzzel
+- [`wofi`](https://hg.sr.ht/~scoopta/wofi) (optional) to use wofi as an action selection menu.
 - [`swappy`](https://github.com/jtheoof/swappy) (optional) to edit the captured
   screenshot.
 - [`dragon`](https://github.com/mwh/dragon) (optional) to drag and drop the

--- a/sway-interactive-screenshot
+++ b/sway-interactive-screenshot
@@ -420,6 +420,43 @@ def ask_rofi(
     return int(stdout) if index else stdout.strip()
 
 
+def ask_wofi(
+    choices: List[Any],
+    *,
+    prompt: Optional[str] = None,
+    lines: Optional[int] = None,
+    index: bool = False,
+    additional_args: Optional[List[str]] = None
+) -> Union[int, str, None]:
+    args = ["wofi", "--dmenu"]
+
+    if index:
+        choices_str = [str(choice) for choice in choices]
+
+    if prompt is not None:
+        args.extend(("--prompt", prompt))
+
+    if lines is not None:
+        args.extend(("--lines", str(lines)))
+
+    if additional_args:
+        args.extend(additional_args)
+
+    process = subprocess.run(
+        args,
+        input=b"\n".join(str(choice).encode() for choice in choices),
+        capture_output=True,
+        check=False,
+    )
+
+    if process.returncode != 0:
+        return None
+
+    stdout = process.stdout.decode()
+
+    return int(choices_str.index(stdout.strip())) if index else stdout.strip()
+
+
 def ask_fuzzel(
     choices: List[Any],
     *,
@@ -459,6 +496,7 @@ def ask_fuzzel(
 
 ASK_FNS = {
     "rofi" : ask_rofi,
+    "wofi" : ask_wofi,
     "fuzzel" : ask_fuzzel
 }
 


### PR DESCRIPTION
Add [Wofi](https://hg.sr.ht/~scoopta/wofi) support to use it as another option for the action selection menu.
To enable it, specify it in the configuration file, and, optionally, specify the path to the style as an additional argument:

```TOML
[ask]
command = "wofi" 
args = ["--style", "/path/to/style"]
```

Since Wofi doesn't have built-in support for returning indices like Fuzzel (--index) or Rofi (-format i), the implementation involves manually calculating the index by comparing the selected item's text against the list of choices.