### PR TITLE
fix: correctly report type errors in config

### DIFF
--- a/sway-interactive-screenshot
+++ b/sway-interactive-screenshot
@@ -64,7 +64,7 @@ def config_type_validator(*types: Type) -> CONFIG_VALIDATOR:
     def validate(path: str, value: Any) -> Iterator[ValidationError]:
         if not isinstance(value, types):
             yield ValidationError(
-                path, f"Type {type(value)} is not one of {', '.join(types)}."
+                path, f"Type {type(value)} is not one of {', '.join(map(str, types))}."
             )
 
     return validate
@@ -86,7 +86,7 @@ def config_list_validator(*types: Type) -> CONFIG_VALIDATOR:
         for i, element in enumerate(value):
             if not isinstance(element, types):
                 yield ValidationError(
-                    f"{path}[{i}]", f"Type {type(value)} is not one of {', '.join(types)}."
+                    f"{path}[{i}]", f"Type {type(value)} is not one of {', '.join(map(str, types))}."
                 )
 
     return validate


### PR DESCRIPTION
Issue
-----

Currently, the types of fields in the configuration is validated when
the configuration is loaded. But the error is not reported correctly:
```
Traceback (most recent call last):
  File "/home/cjoly/ghq/github.com/moverest/sway-interactive-screenshot/./sway-interactive-screenshot", line 922, in <module>
    main()
    ~~~~^^
  File "/home/cjoly/ghq/github.com/moverest/sway-interactive-screenshot/./sway-interactive-screenshot", line 830, in main
    config = Config(args.config)
  File "/home/cjoly/ghq/github.com/moverest/sway-interactive-screenshot/./sway-interactive-screenshot", line 174, in __init__
    errors = list(self._validate("", self.config))
  File "/home/cjoly/ghq/github.com/moverest/sway-interactive-screenshot/./sway-interactive-screenshot", line 58, in validate
    yield from field_validators[field_name](f"{path}.{field_name}", field_value)
  File "/home/cjoly/ghq/github.com/moverest/sway-interactive-screenshot/./sway-interactive-screenshot", line 58, in validate
    yield from field_validators[field_name](f"{path}.{field_name}", field_value)
  File "/home/cjoly/ghq/github.com/moverest/sway-interactive-screenshot/./sway-interactive-screenshot", line 68, in validate
    path, f"Type {type(value)} is not one of {', '.join(types)}."
                                              ~~~~~~~~~^^^^^^^
TypeError: sequence item 0: expected str instance, type found
```
Here, an exception occurs when trying to instantiate `ValidationError`,
because the type `Type` is not a `str`, which `join` expects.

This MR fixes that, so we now print:
```
Traceback (most recent call last):
  File "/home/cjoly/ghq/github.com/moverest/sway-interactive-screenshot/./sway-interactive-screenshot", line 922, in <module>
    main()
    ~~~~^^
  File "/home/cjoly/ghq/github.com/moverest/sway-interactive-screenshot/./sway-interactive-screenshot", line 830, in main
    config = Config(args.config)
  File "/home/cjoly/ghq/github.com/moverest/sway-interactive-screenshot/./sway-interactive-screenshot", line 176, in __init__
    raise ConfigError(errors)
ConfigError: Config errors:
 .screenshot.cursor: Type <class 'str'> is not one of <class 'bool'>.
```

Testing
-------

I triggered the error with the following config:
```toml
[screenshot]
cursor = "false2"
```
